### PR TITLE
Use fprintf with proper format template

### DIFF
--- a/c_src/displayIntermediateValues.c
+++ b/c_src/displayIntermediateValues.c
@@ -110,7 +110,7 @@ void displayRoundNumber(int level, unsigned int i)
 void displayText(int level, const char *text)
 {
     if ((intermediateValueFile) && (level <= displayLevel)) {
-        fprintf(intermediateValueFile, text);
+        fprintf(intermediateValueFile, "%s", text);
         fprintf(intermediateValueFile, "\n");
         fprintf(intermediateValueFile, "\n");
     }


### PR DESCRIPTION
This fixes an issue where GCC will warn about `format-nonliteral`,
which can break compilation.